### PR TITLE
Remove unneeded permissions

### DIFF
--- a/org.gnome.PasswordSafe.json
+++ b/org.gnome.PasswordSafe.json
@@ -6,16 +6,13 @@
     "command" : "gnome-passwordsafe",
     "finish-args" : [
         "--share=ipc",
+        "--socket=fallback-x11",
         "--socket=x11",
         "--socket=wayland",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
         "--filesystem=xdg-run/gvfs",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
-        "--talk-name=ca.desrt.dconf",
+        "--metadata=X-DConf=migrate-path=/org/gnome/PasswordSafe/",
         "--talk-name=org.gtk.vfs",
-        "--talk-name=org.gtk.vfs.*",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.gtk.vfs.*"
     ],
     "modules" : [
         "python3-setuptools_scm.json",


### PR DESCRIPTION
The Flatpak Command Reference suggests using both `x11` and `fallback-x11`:

> The fallback-x11 option makes the X11 socket available only if there is no Wayland socket. This option was introduced in 0.11.3. To support older Flatpak releases, specify both x11 and fallback-x11. The fallback-x11 option takes precedence when both are supported.

[Hardening Flatpak Permissions Over Time](https://blog.tingping.se/2019/10/06/hardening-flatpak-permissions.html) says `--talk-name=org.freedesktop.Notifications` is not needed.

Also fixes #1.