### PR TITLE
Update runtime to GNOME 40

### DIFF
--- a/org.gnome.PasswordSafe.json
+++ b/org.gnome.PasswordSafe.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.PasswordSafe",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "command" : "gnome-passwordsafe",
     "finish-args" : [
@@ -30,23 +30,6 @@
         "python3-setuptools_scm.json",
         "python3-wheel.json",
         "python3-pykeepass.json",
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts": [
-                "-Dexamples=false",
-                "-Dglade_catalog=disabled",
-                "-Dtests=false",
-                "-Dvapi=false"
-            ],
-            "sources" : [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libhandy/1.0/libhandy-1.0.3.tar.xz",
-                    "sha256": "559bb3acc2c362488917eb72ed25bdc181f4ae26ac94d177634cc5d34c867f7a"
-                }
-            ]
-        },
         {
             "name" : "libpwquality",
             "buildsystem" : "autotools",


### PR DESCRIPTION
libhandy was dropped as it is part of the Sdk.