### PR TITLE
Mark as EOL: renamed to org.gnome.World.Secrets

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application has been renamed to org.gnome.World.Secrets.",
+  "end-of-life-rebase": "org.gnome.World.Secrets"
+}

--- a/org.gnome.PasswordSafe.json
+++ b/org.gnome.PasswordSafe.json
@@ -14,7 +14,6 @@
         "/include",
         "/lib/pkgconfig",
         "/lib/cmake",
-        "/lib/debug",
         "/share/pkgconfig",
         "/share/aclocal",
         "/man",


### PR DESCRIPTION
Fixes: https://github.com/flathub/flathub/issues/3108